### PR TITLE
Eliminate flashing in BLE device list

### DIFF
--- a/app/src/main/java/home/bluetooth_scanner/BleDeviceAdapter.kt
+++ b/app/src/main/java/home/bluetooth_scanner/BleDeviceAdapter.kt
@@ -44,7 +44,6 @@ class BleDeviceDiffCallback : DiffUtil.ItemCallback<BleDevice>() {
     override fun areContentsTheSame(oldItem: BleDevice, newItem: BleDevice): Boolean {
         // Compare relevant fields that might change and require UI update
         return oldItem.name == newItem.name &&
-               oldItem.smoothedRssi == newItem.smoothedRssi &&
-               oldItem.currentRssi == newItem.currentRssi
+               oldItem.smoothedRssi == newItem.smoothedRssi
     }
 }

--- a/app/src/main/java/home/bluetooth_scanner/MainActivity.kt
+++ b/app/src/main/java/home/bluetooth_scanner/MainActivity.kt
@@ -18,6 +18,7 @@ import android.content.Intent
 import androidx.core.content.ContextCompat
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
+import androidx.recyclerview.widget.SimpleItemAnimator
 
 class MainActivity : AppCompatActivity() {
 
@@ -160,6 +161,9 @@ class MainActivity : AppCompatActivity() {
         val recyclerView: RecyclerView = findViewById(R.id.devicesRecyclerView)
         recyclerView.layoutManager = LinearLayoutManager(this)
         recyclerView.adapter = bleDeviceAdapter
+
+        // Add this line to disable change animations
+        (recyclerView.itemAnimator as? SimpleItemAnimator)?.supportsChangeAnimations = false
 
         val bluetoothManager = getSystemService(Context.BLUETOOTH_SERVICE) as BluetoothManager
         bluetoothAdapter = bluetoothManager.adapter // Initialize class member


### PR DESCRIPTION
The RecyclerView items representing BLE devices were flashing (fading out and in) upon updates, especially when their signal strength (RSSI) changed, leading to re-sorting.

This was caused by the default item animator's change animations being triggered when DiffUtil detected content updates.

The solution involves two main changes:

1. Disabled item change animations: Set `supportsChangeAnimations = false` on the RecyclerView's item animator in `MainActivity.kt`. This prevents the fade animations on content updates, while still allowing move animations for sorting changes.

2. Refined DiffUtil's `areContentsTheSame`: Updated `BleDeviceDiffCallback` in `BleDeviceAdapter.kt` to only compare `name` and `smoothedRssi` for content changes. This makes the condition for re-binding items more precise to the visually represented data.

These changes ensure that BLE device items update their displayed RSSI values without fading and smoothly animate to new positions if sorting order changes, providing a much smoother user experience.