### PR TITLE
Adjust item spacing and padding in BLE device list

### DIFF
--- a/app/src/main/res/layout/item_ble_device.xml
+++ b/app/src/main/res/layout/item_ble_device.xml
@@ -5,8 +5,8 @@
     android:layout_height="wrap_content"
     app:cardElevation="4dp"
     app:cardCornerRadius="8dp"
-    android:layout_margin="8dp"
-    android:padding="8dp">
+    android:layout_margin="4dp"
+    android:padding="12dp">
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"


### PR DESCRIPTION
Reduces the margin between device list items and increases the internal padding of each item.

- `item_ble_device.xml`:
    - `android:layout_margin` on MaterialCardView changed from `8dp` to `4dp`.
    - `android:padding` on MaterialCardView changed from `8dp` to `12dp`.

This change addresses your request to make the gap between items slightly smaller and add that space to the vertical padding of the items.