### PR TITLE
Implement copy MAC address on tap

### DIFF
--- a/app/src/main/java/home/bluetooth_scanner/BleDeviceAdapter.kt
+++ b/app/src/main/java/home/bluetooth_scanner/BleDeviceAdapter.kt
@@ -1,11 +1,14 @@
 package home.bluetooth_scanner
 
+import android.content.ClipData
+import android.content.ClipboardManager
 import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.ProgressBar
 import android.widget.TextView
+import android.widget.Toast
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
@@ -34,6 +37,16 @@ class BleDeviceAdapter : ListAdapter<BleDevice, BleDeviceAdapter.BleDeviceViewHo
             deviceNameTextView.text = device.name ?: "Unknown Device"
             deviceAddressTextView.text = device.address
             deviceRssiTextView.text = String.format("%.0f dBm", device.smoothedRssi)
+
+            itemView.setOnClickListener {
+                val context = itemView.context
+                val clipboardManager =
+                    context.getSystemService(ClipboardManager::class.java) as ClipboardManager
+                val clipData = ClipData.newPlainText("MAC Address", device.address)
+                clipboardManager.setPrimaryClip(clipData)
+                Toast.makeText(context, context.getString(R.string.mac_address_copied), Toast.LENGTH_SHORT)
+                    .show()
+            }
 
             // Logic for RSSI strength bar
             // Note: RSSI is typically negative. Closer to 0 is stronger.

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,3 +1,4 @@
 <resources>
     <string name="app_name">Bluetooth scanner</string>
+    <string name="mac_address_copied">MAC address copied to clipboard</string>
 </resources>


### PR DESCRIPTION
This feature allows you to copy the MAC address of a BLE device by tapping on it in the device list.

Changes:
- Modified `BleDeviceViewHolder` in `BleDeviceAdapter.kt` to add an `onClickListener` to the item view.
- When an item is clicked, the MAC address of the corresponding `BleDevice` is copied to the clipboard using `ClipboardManager`.
- A Toast message "MAC address copied to clipboard" is displayed to confirm the action. The message uses a string resource `R.string.mac_address_copied`.
- Added the string resource to `app/src/main/res/values/strings.xml`.

Unit tests for this functionality were written but could not be executed due to limitations in the testing environment (Android SDK not found).