### PR TITLE
Ensure KEYSTORE_PATH is correctly set in release workflow

### DIFF
--- a/.github/workflows/android_release.yml
+++ b/.github/workflows/android_release.yml
@@ -39,12 +39,15 @@ jobs:
         run: chmod +x ./gradlew
 
       - name: Build with Gradle (Release APK)
-        run: ./gradlew assembleRelease
         env:
-          KEYSTORE_PATH: ${{ env.HOME }}/release.p12
+          # KEYSTORE_PATH will be set in the run command using shell expansion
           KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
           KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
           KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
+        run: |
+          export KEYSTORE_PATH="$HOME/release.p12"
+          echo "KEYSTORE_PATH is set to: $KEYSTORE_PATH"
+          ./gradlew assembleRelease
 
       - name: Create GitHub Release
         id: create_release


### PR DESCRIPTION
The previous method of setting KEYSTORE_PATH using `${{ env.HOME }}/release.p12` in the `env` map appeared to result in the path being resolved as `/release.p12` within Gradle, causing build failures.

This change modifies the GitHub Actions release workflow to set the KEYSTORE_PATH environment variable directly within the `run` script block using shell expansion (`export KEYSTORE_PATH="$HOME/release.p12"`). This ensures that `$HOME` is correctly expanded and KEYSTORE_PATH provides the valid absolute path to the keystore file for the Gradle build process.

Reverted previous workaround in `app/build.gradle.kts` as the fix is now in the CI configuration.