### PR TITLE
Fix: Grant contents:write permission for release creation

### DIFF
--- a/.github/workflows/android_release.yml
+++ b/.github/workflows/android_release.yml
@@ -12,6 +12,8 @@ jobs:
   build-and-release:
     name: Build and Create Release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
The actions/create-release@v1 action requires `contents: write` permission to create GitHub releases. This commit adds the necessary permission to the `build-and-release` job in the `android_release.yml` workflow.