### PR TITLE
Improve robustness of applicationIdSuffix generation

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -9,9 +9,10 @@ fun getGitUserSuffix(): String {
         val remoteUrl = process.inputStream.bufferedReader().readText().trim()
         process.waitFor()
         // Regex for git@github.com:owner/repo and https://github.com/owner/repo capturing the owner
-        val regex = Regex("[:/]([^/]+)/[^/]+\\.git$")
+        // Now also handles optional .git suffix and optional trailing slash
+        val regex = Regex("[:/]([^/]+)/[^/]+(\\.git)?/?$")
         val matchResult = regex.find(remoteUrl)
-        return matchResult?.groups?.get(1)?.value?.lowercase()?.let { ".$it" } ?: ""
+        return matchResult?.groups?.get(1)?.value?.lowercase()?.let { ".$it" } ?: ".local"
     } catch (e: Exception) {
         println("Could not get git user: ${e.message}")
         return ".local"


### PR DESCRIPTION
This PR enhances the getGitUserSuffix function:

1. Fallback to ".local": Ensures that if the git username cannot be extracted (either due to an exception or regex mismatch), the suffix defaults to ".local" instead of an empty string.
2. Improved Regex: The regex for parsing the git remote URL has been updated to `[:/]([^/]+)/[^/]+(\.git)?/?$`. This makes the trailing `.git` optional and also correctly handles an optional trailing slash in the URL.

These changes make the applicationIdSuffix generation more resilient to variations in git remote URL formatting and ensure a suffix is always applied.