### PR TITLE
Unify ProgressBar and button colors

### DIFF
--- a/app/src/main/res/layout/item_ble_device.xml
+++ b/app/src/main/res/layout/item_ble_device.xml
@@ -21,6 +21,7 @@
             android:indeterminate="false"
             android:max="100"
             android:progress="0"
+            android:progressTint="?attr/colorPrimary"
             app:layout_constraintTop_toTopOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintEnd_toEndOf="parent" />


### PR DESCRIPTION
The ProgressBar for signal strength now uses the theme's `colorPrimary`, ensuring its color matches the buttons in both light and dark modes.

This change was made by adding `android:progressTint="?attr/colorPrimary"` to the ProgressBar in `item_ble_device.xml`.